### PR TITLE
Test LLVM-WASM support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -373,4 +373,6 @@ jobs:
             export PATH=$HOME/wasmtime-v19.0.2-x86_64-linux:$PATH
             export WASMTIME_NEW_CLI=0
             cd integration_tests
-            ./run_tests.py -b llvm_wasm llvm_wasm_emcc
+            # llvm_wasm requires lfortran_runtime_wasm_wasi.o which is
+            # currently missing
+            ./run_tests.py -b llvm_wasm_emcc

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -314,6 +314,7 @@ jobs:
             which lfortran
 
       - name: Setup WASI SDK
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         shell: bash -e -l {0}
         run: |
           cd $HOME
@@ -324,6 +325,7 @@ jobs:
           $WASI_SDK_PATH/bin/clang --version
 
       - name: Install wasmtime
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         shell: bash -e -l {0}
         run: |
           cd $HOME
@@ -332,6 +334,7 @@ jobs:
           wasmtime --version
 
       - name: Setup EMSCRIPTEN SDK
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         shell: bash -e -l {0}
         run: |
           cd $HOME
@@ -360,7 +363,7 @@ jobs:
 
 
       - name: Run LFortran WASM Tests
-        if: ${{ !startsWith(matrix.os, 'windows-2019') }}
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         shell: bash -e -x -l {0}
         run: |
             cd lfortran

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -329,7 +329,8 @@ jobs:
         shell: bash -e -l {0}
         run: |
           cd $HOME
-          curl -o wasmtime.tar.gz -L https://github.com/bytecodealliance/wasmtime/releases/download/v19.0.2/wasmtime-v19.0.2-x86_64-linux.tar.xz                 tar -xvf wasmtime.tar.gz
+          curl -o wasmtime.tar.gz -L https://github.com/bytecodealliance/wasmtime/releases/download/v19.0.2/wasmtime-v19.0.2-x86_64-linux.tar.xz
+          tar -xvf wasmtime.tar.gz
           export PATH=$HOME/wasmtime-v19.0.2-x86_64-linux:$PATH
           wasmtime --version
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -313,6 +313,36 @@ jobs:
             micromamba list
             which lfortran
 
+      - name: Setup WASI SDK
+        shell: bash -e -l {0}
+        run: |
+          cd $HOME
+          curl -o wasi-sdk.tar.gz -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-21/wasi-sdk-21.0-linux.tar.gz
+          tar -xvf wasi-sdk.tar.gz
+          export WASI_SDK_PATH=$HOME/wasi-sdk-21.0
+          echo $WASI_SDK_PATH
+          $WASI_SDK_PATH/bin/clang --version
+
+      - name: Install wasmtime
+        shell: bash -e -l {0}
+        run: |
+          cd $HOME
+          curl -o wasmtime.tar.gz -L https://github.com/bytecodealliance/wasmtime/releases/download/v19.0.2/wasmtime-v19.0.2-x86_64-linux.tar.xz                 tar -xvf wasmtime.tar.gz
+          export PATH=$HOME/wasmtime-v19.0.2-x86_64-linux:$PATH
+          wasmtime --version
+
+      - name: Setup EMSCRIPTEN SDK
+        shell: bash -e -l {0}
+        run: |
+          cd $HOME
+          curl -o emsdk.tar.gz -L https://github.com/emscripten-core/emsdk/archive/refs/tags/3.1.59.tar.gz
+          tar -xvf emsdk.tar.gz
+          export EMSDK_PATH=$HOME/emsdk-3.1.59
+          echo $EMSDK_PATH
+          cd $EMSDK_PATH
+          ./emsdk install latest
+          ./emsdk activate latest
+
       - name: Clone LFortran Source Repository
         shell: bash -e -x -l {0}
         run: |
@@ -327,3 +357,16 @@ jobs:
         run: |
             cd lfortran
             ./run_tests.py --skip-run-with-dbg --no-llvm --skip-cpptranslate
+
+
+      - name: Run LFortran WASM Tests
+        if: ${{ !startsWith(matrix.os, 'windows-2019') }}
+        shell: bash -e -x -l {0}
+        run: |
+            cd lfortran
+            export WASI_SDK_PATH=$HOME/wasi-sdk-21.0
+            export EMSDK_PATH=$HOME/emsdk-3.1.59
+            export PATH=$HOME/wasmtime-v19.0.2-x86_64-linux:$PATH
+            export WASMTIME_NEW_CLI=0
+            cd integration_tests
+            ./run_tests.py -b llvm_wasm llvm_wasm_emcc


### PR DESCRIPTION
This enables testing the LLVM WASM support in LFortran. Both that it was compiled with -DWITH_TARGET_WASM=yes and that the C runtime library was compiled to WASM and shipped with the lfortran conda package.